### PR TITLE
Added a couple useful overloads and fixed a comment.

### DIFF
--- a/source/scone/window.d
+++ b/source/scone/window.d
@@ -108,6 +108,8 @@ struct Window
             }
         }
     }
+    ///ditto
+    auto write(Args...)(in size_t[2] pos, Args args) {write(pos[0],pos[1], args);}
 
     ///Displays what has been written
     auto print()
@@ -289,12 +291,16 @@ struct Window
             _cells[n][] = Cell(' ', defaultForeground, defaultBackground);
         }
     }
+    ///ditto
+    auto resize(in size_t[2] size) {resize(size[0],size[1]);}
 
     //Reposition the window.
     auto reposition(in size_t x, in size_t y)
     {
         OS.reposition(x,y);
     }
+    ///ditto
+    auto reposition(in size_t[2] pos) {resize(pos[0],pos[1]);}
 
     ///Get the width of the window
     auto width()
@@ -312,6 +318,12 @@ struct Window
     alias w = width;
     ///
     alias h = height;
+
+    ///Get the size of the window
+    size_t[2] size()
+    {
+        return [width,height];
+    }
 
     ///The default foreground color used with `window.write(x, y, ...);`
     public fg defaultForeground = fg(Color.white_dark);

--- a/source/scone/window.d
+++ b/source/scone/window.d
@@ -262,7 +262,7 @@ struct Window
         }
     }
 
-    ///Set the size of the window
+    ///Set the title of the window
     auto title(in string title) @property
     {
         OS.title(title);


### PR DESCRIPTION
Fixed doc comment.
Window.tite doc comment was:
///Set the size of the window
Should be (and now is):
///Set the title of the window


Added function overloads for `write` and `resize` to accept x and y together as `size_t[2]`.  Also added a `size` method for `w` and `h`.

Using an array for pos and size is not entirly common in C++ due to arrays being a pain to use.
But in higher level languages like python (particularly pygame) this is used.
And with D arrays are easier to use than in C++ so I prefer using an array.