### PR TITLE
Fix ulong[2] to int[2] implicit cast error

### DIFF
--- a/source/scone/os.d
+++ b/source/scone/os.d
@@ -240,16 +240,22 @@ struct OS
             //todo...
         }
 
-        size_t[2] size()
+        int[2] size()
         {
+            import std.conv : to;
+
             GetConsoleScreenBufferInfo(_hConsoleOutput, &_consoleScreenBufferInfo);
 
             return
             [
-                _consoleScreenBufferInfo.srWindow.Right -
-                _consoleScreenBufferInfo.srWindow.Left + 1,
-                _consoleScreenBufferInfo.srWindow.Bottom -
-                _consoleScreenBufferInfo.srWindow.Top  + 1
+                to!int(
+                    _consoleScreenBufferInfo.srWindow.Right -
+                    _consoleScreenBufferInfo.srWindow.Left + 1
+                ),
+                to!int(
+                    _consoleScreenBufferInfo.srWindow.Bottom -
+                    _consoleScreenBufferInfo.srWindow.Top  + 1
+                )
             ];
         }
 


### PR DESCRIPTION
In dmd 2.079.0, scone was failing to compile with an error about not being able to implicitly convert an `ulong[2]` (aka `size_t[2]`) array to `int[2]`. This fixes that error.