### PR TITLE
Fix out of range with newlines

### DIFF
--- a/source/scone/window.d
+++ b/source/scone/window.d
@@ -151,6 +151,7 @@ struct Window
             {
                 wx = 0;
                 ++wy;
+				if (wy >= cells.length) break;
                 continue;
             }
 

--- a/source/scone/window.d
+++ b/source/scone/window.d
@@ -151,7 +151,7 @@ struct Window
             {
                 wx = 0;
                 ++wy;
-				if (wy >= cells.length) break;
+                if (wy >= cells.length) break;
                 continue;
             }
 

--- a/source/scone/window.d
+++ b/source/scone/window.d
@@ -151,7 +151,10 @@ struct Window
             {
                 wx = 0;
                 ++wy;
-                if (wy >= cells.length) break;
+                if (wy >= cells.length) 
+                {
+                    break;
+                }
                 continue;
             }
 


### PR DESCRIPTION
When the text drops below the window, you previously got an out of range error. Since there is a check whether the start fits in the border, it would also be nice if it were defensive about later characters falling out of the border.