### PR TITLE
Make scone compile on 64-bit targets

### DIFF
--- a/source/scone/window.d
+++ b/source/scone/window.d
@@ -170,9 +170,9 @@ struct Window
         // Windows version of printing, using winapi (super duper fast)
         version(Windows)
         {
-            foreach(cy, ref y; cells)
+            foreach(uint cy, ref y; cells)
             {
-                foreach(cx, ref cell; y)
+                foreach(uint cx, ref cell; y)
                 {
                     if(cell != backbuffer[cy][cx])
                     {


### PR DESCRIPTION
Because the type of array lengths are dependent on platform, cx and cy are inferred to be `ulong` on 64-bit targets causing an error when they are passed to `OS.Windows.writeCell` which expects `uints`.