### PR TITLE
Fix deprecation of loop index conversion

### DIFF
--- a/source/scone/window.d
+++ b/source/scone/window.d
@@ -201,13 +201,13 @@ struct Window
         // Windows version of printing, using winapi (super duper fast)
         version (Windows)
         {
-            foreach (uint cy, ref y; cells)
+            foreach (cy, ref y; cells)
             {
-                foreach (uint cx, ref cell; y)
+                foreach (cx, ref cell; y)
                 {
                     if (cell != backbuffer[cy][cx])
                     {
-                        WindowsOS.writeCell(cx, cy, cell);
+                        WindowsOS.writeCell(cast(uint) cx, cast(uint) cy, cell);
 
                         // update backbuffer
                         backbuffer[cy][cx] = cell;


### PR DESCRIPTION
Fixes these deprecations:
```
source\scone\window.d(204,13): Deprecation: foreach: loop index implicitly converted from size_t to uint
source\scone\window.d(206,17): Deprecation: foreach: loop index implicitly converted from size_t to uint
```