### PR TITLE
Rename Input to Keyboard

### DIFF
--- a/source/scone/core/init.d
+++ b/source/scone/core/init.d
@@ -2,7 +2,7 @@ module scone.core.init;
 
 import scone.frame.frame : Frame;
 import scone.input.keyboard : Keyboard;
-import scone.os.input : Input_ = Input;
+import scone.os.input : Input;
 import scone.os.output : Output;
 import std.experimental.logger;
 
@@ -14,8 +14,8 @@ void delegate() sconeSetup = {
     auto output = createApplicationOutput();
     frame = new Frame(output);
 
-    auto input_ = createApplicationInput();
-    keyboard = new Keyboard(input_);
+    auto input = createApplicationInput();
+    keyboard = new Keyboard(input);
 };
 
 private shared initialized = false;
@@ -55,7 +55,7 @@ Output createApplicationOutput()
     }
 }
 
-Input_ createApplicationInput()
+Input createApplicationInput()
 {
     version (unittest)
     {

--- a/source/scone/core/init.d
+++ b/source/scone/core/init.d
@@ -1,13 +1,13 @@
 module scone.core.init;
 
 import scone.frame.frame : Frame;
-import scone.input.input : Input;
+import scone.input.keyboard : Keyboard;
 import scone.os.input : Input_ = Input;
 import scone.os.output : Output;
 import std.experimental.logger;
 
 Frame frame;
-Input input;
+Keyboard keyboard;
 
 /// can be overidden
 void delegate() sconeSetup = {
@@ -15,7 +15,7 @@ void delegate() sconeSetup = {
     frame = new Frame(output);
 
     auto input_ = createApplicationInput();
-    input = new Input(input_);
+    keyboard = new Keyboard(input_);
 };
 
 private shared initialized = false;

--- a/source/scone/core/types/buffer.d
+++ b/source/scone/core/types/buffer.d
@@ -1,6 +1,5 @@
 module scone.core.types.buffer;
 
-import scone.input.input_event;
 import scone.core.types.cell : Cell;
 import scone.core.types.color;
 import scone.core.types.coordinate : Coordinate;

--- a/source/scone/input/input.d
+++ b/source/scone/input/input.d
@@ -1,7 +1,7 @@
 module scone.input.input;
 
 import scone.os.input : OSInput = Input;
-import scone.input.input_event : InputEvent;
+import scone.input.keyboard_event : KeyboardEvent;
 
 class Input
 {
@@ -18,8 +18,8 @@ class Input
         this.input.deinitializeInput();
     }
 
-    InputEvent[] latest()
+    KeyboardEvent[] latest()
     {
-        return this.input.latestInputEvents();
+        return this.input.latestKeyboardEvents();
     }
 }

--- a/source/scone/input/keyboard.d
+++ b/source/scone/input/keyboard.d
@@ -1,13 +1,13 @@
 module scone.input.keyboard;
 
-import scone.os.input : OSInput = Input;
+import scone.os.input : Input;
 import scone.input.keyboard_event : KeyboardEvent;
 
 class Keyboard
 {
-    private OSInput input;
+    private Input input;
 
-    this(OSInput input)
+    this(Input input)
     {
         this.input = input;
         input.initializeInput();

--- a/source/scone/input/keyboard.d
+++ b/source/scone/input/keyboard.d
@@ -1,9 +1,9 @@
-module scone.input.input;
+module scone.input.keyboard;
 
 import scone.os.input : OSInput = Input;
 import scone.input.keyboard_event : KeyboardEvent;
 
-class Input
+class Keyboard
 {
     private OSInput input;
 

--- a/source/scone/input/keyboard_event.d
+++ b/source/scone/input/keyboard_event.d
@@ -1,26 +1,16 @@
-module scone.input.input_event;
+module scone.input.keyboard_event;
 
 import scone.input.scone_key : SK;
 import scone.input.scone_control_key : SCK;
 import scone.misc.flags : hasFlag;
 
-struct InputEvent
+struct KeyboardEvent
 {
     this(SK key, SCK controlKey, bool pressed)
     {
-        _key = key;
-        _controlKey = controlKey;
-        _pressed = pressed;
-    }
-
-    auto key() @property
-    {
-        return _key;
-    }
-
-    auto pressed() @property
-    {
-        return _pressed;
+        this.key = key;
+        this.controlKey = controlKey;
+        this.pressed = pressed;
     }
 
     auto hasControlKey(SCK ck)
@@ -28,14 +18,9 @@ struct InputEvent
         return controlKey.hasFlag(ck);
     }
 
-    auto controlKey() @property
-    {
-        return _controlKey;
-    }
-
-    private SK _key;
-    private SCK _controlKey;
-    private bool _pressed;
+    public SK key;
+    public SCK controlKey;
+    public bool pressed;
 
     /+
     version (Posix)

--- a/source/scone/misc/dummy_window.d
+++ b/source/scone/misc/dummy_window.d
@@ -2,7 +2,7 @@ module scone.misc.dummy_window;
 
 import scone.core.types.buffer : Buffer;
 import scone.core.types.size : Size;
-import scone.input.input_event : InputEvent;
+import scone.input.keyboard_event : KeyboardEvent;
 import scone.os.output : Output;
 import scone.os.input : Input;
 
@@ -48,7 +48,7 @@ class DummyInput : Input
     {
     }
 
-    InputEvent[] latestInputEvents()
+    KeyboardEvent[] latestKeyboardEvents()
     {
         return [];
     }

--- a/source/scone/os/input.d
+++ b/source/scone/os/input.d
@@ -1,10 +1,10 @@
 module scone.os.input;
 
-import scone.input.input_event : InputEvent;
+import scone.input.keyboard_event : KeyboardEvent;
 
 interface Input
 {
     public void initializeInput();
     public void deinitializeInput();
-    public InputEvent[] latestInputEvents();
+    public KeyboardEvent[] latestKeyboardEvents();
 }

--- a/source/scone/os/output.d
+++ b/source/scone/os/output.d
@@ -3,7 +3,7 @@ module scone.os.output;
 import scone.core.types.buffer : Buffer;
 import scone.core.types.coordinate : Coordinate;
 import scone.core.types.size : Size;
-import scone.input.input_event : InputEvent;
+import scone.input.keyboard_event : KeyboardEvent;
 
 interface Output
 {

--- a/source/scone/os/posix/input/background_thread.d
+++ b/source/scone/os/posix/input/background_thread.d
@@ -11,7 +11,7 @@ version (Posix)
     import std.concurrency : thisTid, send, ownerTid;
     import std.datetime : Duration, msecs;
 
-    static void pollInputEvent()
+    static void pollKeyboardEvent()
     {
         Thread.getThis.isDaemon = true;
 

--- a/source/scone/os/posix/input/locale/input_map.d
+++ b/source/scone/os/posix/input/locale/input_map.d
@@ -2,7 +2,7 @@ module scone.os.posix.input.locale.input_map;
 
 version (Posix)
 {
-    import scone.input.input_event : InputEvent;
+    import scone.input.keyboard_event : KeyboardEvent;
     import scone.input.scone_control_key : SCK;
     import scone.input.scone_key : SK;
     import scone.os.posix.input.keypress_tree : KeypressTree, Keypress;
@@ -17,7 +17,7 @@ version (Posix)
             loadKeypressTree(this.keypressTree, tsv);
         }
 
-        Keypress[] inputEventsFromSequence(uint[] sequence)
+        Keypress[] keyboardEventsFromSequence(uint[] sequence)
         {
             return this.keypressTree.find(sequence);
         }

--- a/source/scone/os/posix/input/posix_input.d
+++ b/source/scone/os/posix/input/posix_input.d
@@ -9,7 +9,7 @@ version (Posix)
     import scone.core.types.color;
     import scone.core.types.coordinate : Coordinate;
     import scone.core.types.size : Size;
-    import scone.input.input_event : InputEvent;
+    import scone.input.keyboard_event : KeyboardEvent;
     import scone.input.scone_control_key : SCK;
     import scone.input.scone_key : SK;
     import scone.os.input : Input;
@@ -53,30 +53,30 @@ version (Posix)
             return sequence;
         }
 
-        InputEvent[] latestInputEvents()
+        KeyboardEvent[] latestKeyboardEvents()
         {
             auto sequence = this.retreiveInputSequence();
 
-            //todo: returns null here. should this logic be here or in `inputMap.inputEventsFromSequence(sequence)` instead?
+            //todo: returns null here. should this logic be here or in `inputMap.keyboardEventsFromSequence(sequence)` instead?
             if (sequence.length == 0)
             {
                 return null;
             }
 
             // conversion to input events. refactor whole (winodws+posix) code to use keypresses instead of input events?
-            InputEvent[] inputEvents = [];
-            foreach (Keypress keypress; inputMap.inputEventsFromSequence(sequence))
+            KeyboardEvent[] keyboardEvents = [];
+            foreach (Keypress keypress; inputMap.keyboardEventsFromSequence(sequence))
             {
-                inputEvents ~= InputEvent(keypress.key, keypress.controlKey, true);
+                keyboardEvents ~= KeyboardEvent(keypress.key, keypress.controlKey, true);
             }
 
-            return inputEvents;
+            return keyboardEvents;
         }
 
         private void startPollingInput()
         {
             // begin polling
-            spawn(&pollInputEvent);
+            spawn(&pollKeyboardEvent);
         }
 
         // unsure when to use this.

--- a/source/scone/os/windows/input/windows_input.d
+++ b/source/scone/os/windows/input/windows_input.d
@@ -2,7 +2,7 @@ module scone.os.windows.input.windows_input;
 
 version (Windows)
 {
-    import scone.os.input : Input_ = Input;
+    import scone.os.input : Input;
     import core.sys.windows.windows;
     import scone.core.types.size : Size;
     import scone.input.keyboard : Keyboard;
@@ -14,7 +14,7 @@ version (Windows)
     import std.conv : to;
     import std.experimental.logger;
 
-    class WindowsInput : Input_
+    class WindowsInput : Input
     {
         void initializeInput()
         {

--- a/source/scone/os/windows/input/windows_input.d
+++ b/source/scone/os/windows/input/windows_input.d
@@ -6,7 +6,7 @@ version (Windows)
     import core.sys.windows.windows;
     import scone.core.types.size : Size;
     import scone.input.input : Input;
-    import scone.input.input_event : InputEvent;
+    import scone.input.keyboard_event : KeyboardEvent;
     import scone.input.scone_control_key : SCK;
     import scone.input.scone_key : SK;
     import scone.misc.flags : hasFlag, withFlag;
@@ -29,13 +29,13 @@ version (Windows)
         {
         }
 
-        InputEvent[] latestInputEvents()
+        KeyboardEvent[] latestKeyboardEvents()
         {
             INPUT_RECORD[16] inputRecordBuffer;
             DWORD read = 0;
             ReadConsoleInput(consoleInputHandle, inputRecordBuffer.ptr, 16, &read);
 
-            InputEvent[] inputEvents;
+            KeyboardEvent[] keyboardEvents;
 
             for (size_t e = 0; e < read; ++e)
             {
@@ -53,13 +53,13 @@ version (Windows)
                     break;
                 case  /* 0x0001 */ KEY_EVENT:
                     auto foo = new KeyEventRecordConverter(inputRecordBuffer[e].KeyEvent);
-                    inputEvents ~= InputEvent(foo.sconeKey, foo.sconeControlKey,
+                    keyboardEvents ~= KeyboardEvent(foo.sconeKey, foo.sconeControlKey,
                             cast(bool) inputRecordBuffer[e].KeyEvent.bKeyDown);
                     break;
                 }
             }
 
-            return inputEvents;
+            return keyboardEvents;
         }
 
         private HANDLE consoleInputHandle;

--- a/source/scone/os/windows/input/windows_input.d
+++ b/source/scone/os/windows/input/windows_input.d
@@ -5,7 +5,7 @@ version (Windows)
     import scone.os.input : Input_ = Input;
     import core.sys.windows.windows;
     import scone.core.types.size : Size;
-    import scone.input.input : Input;
+    import scone.input.keyboard : Keyboard;
     import scone.input.keyboard_event : KeyboardEvent;
     import scone.input.scone_control_key : SCK;
     import scone.input.scone_key : SK;

--- a/source/scone/package.d
+++ b/source/scone/package.d
@@ -1,13 +1,13 @@
 module scone;
 
-public import scone.core.init : frame, input, sconeSetup;
+public import scone.core.init : frame, keyboard, sconeSetup;
 public import scone.core.types.cell : Cell;
 public import scone.core.types.color;
 public import scone.core.types.coordinate : Coordinate;
 public import scone.core.types.size : Size;
 public import scone.frame.frame;
 public import scone.input.keyboard_event;
-public import scone.input.input;
+public import scone.input.keyboard;
 public import scone.input.scone_control_key;
 public import scone.input.scone_key;
 public import scone.misc.flags;

--- a/source/scone/package.d
+++ b/source/scone/package.d
@@ -6,7 +6,7 @@ public import scone.core.types.color;
 public import scone.core.types.coordinate : Coordinate;
 public import scone.core.types.size : Size;
 public import scone.frame.frame;
-public import scone.input.input_event;
+public import scone.input.keyboard_event;
 public import scone.input.input;
 public import scone.input.scone_control_key;
 public import scone.input.scone_key;


### PR DESCRIPTION
Changes the name of the high-level `Input` class to `Keyboard`.