### PR TITLE
Remove ForegroundColor and BackgroundColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ void main() {
     frame.write(
       12, 9,
       TextStyle().fg(Color.yellow), "Hello ", // color text
-      Color.red.foreground, Color.white.background, "World" // alternative way
+      TextStyle().fg(Color.red).bg(Color.red), "World"
     );
     frame.print();
   }

--- a/source/scone/output/buffer.d
+++ b/source/scone/output/buffer.d
@@ -130,9 +130,9 @@ unittest
     assert(buffer.diffs == [Coordinate(1, 1)]);
     buffer.commit();
 
-    buffer.stage(Coordinate(0, 0), Cell('2', TextStyle(Color.red.foreground, Color.green.background)));
+    buffer.stage(Coordinate(0, 0), Cell('2', TextStyle(Color.red, Color.green)));
     assert(buffer.diffs.length == 1);
     buffer.commit();
-    buffer.stage(Coordinate(0, 0), Cell('2', TextStyle(Color.same.foreground, Color.same.background)));
+    buffer.stage(Coordinate(0, 0), Cell('2', TextStyle(Color.same, Color.same)));
     assert(buffer.diffs.length == 0);
 }

--- a/source/scone/output/frame.d
+++ b/source/scone/output/frame.d
@@ -181,6 +181,10 @@ unittest
     assert(frame.buffer.get(Coordinate(2, 0)) == Cell('X', TextStyle(Color.green, Color.initial)));
     assert(frame.buffer.get(Coordinate(3, 0)) == Cell(' ', TextStyle(Color.initial, Color.initial)));
     assert(frame.buffer.get(Coordinate(4, 0)) == Cell('4', TextStyle(Color.red, Color.initial)));
+
+    frame.print();
+    frame.write(0, 1, TextStyle().fg(Color.red), TextStyle().bg(Color.green), "X");
+    assert(frame.buffer.get(Coordinate(0, 1)) == Cell('X', TextStyle(Color.red, Color.green)));
 }
 /// cells use its own style, independen of previous text style
 unittest

--- a/source/scone/output/helpers/arguments_to_cells_converter.d
+++ b/source/scone/output/helpers/arguments_to_cells_converter.d
@@ -29,15 +29,15 @@ class ArgumentsToCellsConverter(Args...)
         {
             static if (is(typeof(arg) == TextStyle))
             {
-                textStyle = arg;
-            }
-            else static if (is(typeof(arg) == ForegroundColor))
-            {
-                textStyle.foreground = arg;
-            }
-            else static if (is(typeof(arg) == BackgroundColor))
-            {
-                textStyle.background = arg;
+                if(arg.foreground != Color.same)
+                {
+                    textStyle.foreground = arg.foreground;
+                }
+                
+                if(arg.background != Color.same)
+                {
+                    textStyle.background = arg.background;
+                }
             }
             else static if (is(typeof(arg) == Cell))
             {
@@ -87,7 +87,7 @@ class ArgumentsToCellsConverter(Args...)
             {
                 continue;
             }
-            else static if (is(typeof(arg) : Color))
+            else static if (is(typeof(arg) == Color))
             {
                 continue;
             }
@@ -125,24 +125,16 @@ unittest
     assert(converter1.length == 0);
 
     auto converter2 = new ArgumentsToCellsConverter!(int, int, int)(0, 0, 0);
-    assert(converter2.cells == [Cell('0', TextStyle(Color.same.foreground, Color.same.background)), Cell('0', TextStyle(Color.same.foreground, Color.same.background)), Cell('0', TextStyle(Color.same.foreground, Color.same.background))]);
+    assert(converter2.cells == [Cell('0', TextStyle(Color.same, Color.same)), Cell('0', TextStyle(Color.same, Color.same)), Cell('0', TextStyle(Color.same, Color.same))]);
     assert(converter2.length == 3);
 
     auto converter3 = new ArgumentsToCellsConverter!(string)("foo");
-    assert(converter3.cells == [Cell('f', TextStyle(Color.same.foreground, Color.same.background)), Cell('o', TextStyle(Color.same.foreground, Color.same.background)), Cell('o', TextStyle(Color.same.foreground, Color.same.background))]);
+    assert(converter3.cells == [Cell('f', TextStyle(Color.same, Color.same)), Cell('o', TextStyle(Color.same, Color.same)), Cell('o', TextStyle(Color.same, Color.same))]);
     assert(converter3.length == 3);
 
-    auto converter4 = new ArgumentsToCellsConverter!(string, ForegroundColor, string, BackgroundColor, string)("f", Color.red.foreground, "o", Color.green.background, "o");
-    assert(converter4.cells == [Cell('f', TextStyle(Color.same.foreground, Color.same.background)), Cell('o', TextStyle(Color.red.foreground, Color.same.background)), Cell('o', TextStyle(Color.red.foreground, Color.green.background))]);
+    auto converter4 = new ArgumentsToCellsConverter!(Cell, Cell[])(Cell('1'), [Cell('2'), Cell('3')]);
+    assert(converter4.cells == [Cell('1'), Cell('2'), Cell('3')]);
     assert(converter4.length == 3);
-
-    auto converter5 = new ArgumentsToCellsConverter!(Cell, Cell[])(Cell('1'), [Cell('2'), Cell('3')]);
-    assert(converter5.cells == [Cell('1'), Cell('2'), Cell('3')]);
-    assert(converter5.length == 3);
-
-    auto converter6 = new ArgumentsToCellsConverter!(ForegroundColor, BackgroundColor)(Color.red.foreground, Color.green.background);
-    assert(converter6.cells == []);
-    assert(converter6.length == 0);
 }
 /// text style
 unittest

--- a/source/scone/output/types/color.d
+++ b/source/scone/output/types/color.d
@@ -55,111 +55,38 @@ unittest
     assert(Color.whiteDark - Color.blackDark == 7);
 }
 
-/// both `ForegroundColor` and `BackgroundColor` work the same way. this is not not have duplicate code :)
-private template ColorTemplate()
-{
-    this(Color c)
-    {
-        color = c;
-    }
-
-    Color color;
-    alias color this;
-}
-
-/// Container for foreground colors
-struct ForegroundColor
-{
-    mixin ColorTemplate;
-}
-
-/// Container for background colors
-struct BackgroundColor
-{
-    mixin ColorTemplate;
-}
-
-/**
- * Example:
- * ---
- * window.write(0,0, Color.red.foreground, "string");
- * ---
- */
-ForegroundColor foreground(Color color)
-{
-    return ForegroundColor(color);
-}
-
-/**
- * Example:
- * ---
- * window.write(0,0, Color.blue.background, "string");
- * ---
- */
-BackgroundColor background(Color color)
-{
-    return BackgroundColor(color);
-}
-
-/**
- * Check if a color is a light color
- * Params:
- *     color = A type of color. Either `Color`, `ForegroundColor`, or `BackgroundColor`
- * Return: bool, true if light color, false otherwise
- */
-pure auto isLight(C)(C color) if (is(C : Color))
+pure auto isLight(Color color)
 {
     return color >= Color.black && color <= Color.white;
 }
-///
-@system unittest
+unittest
 {
     assert(Color.red.isLight);
     assert(!Color.redDark.isLight);
-    assert(Color.red.foreground.isLight);
-    assert(background(Color.red).isLight);
 }
 
-/**
- * Check if a color is a dark color
- * Params:
- *     color = A type of color. Either `Color`, `ForegroundColor`, or `BackgroundColor`
- * Return: bool, true if dark color, false otherwise
- */
-pure auto isDark(C)(C color) if (is(C : Color))
+auto isDark(Color color)
 {
     return color >= Color.blackDark && color <= Color.whiteDark;
 }
-///
-@system unittest
+unittest
 {
     assert(!Color.red.isDark);
     assert(Color.redDark.isDark);
-    assert(Color.redDark.foreground.isDark);
-    assert(background(Color.redDark).isDark);
 }
 
-/**
- * See if color is a proper color
- */
-pure auto isActualColor(C)(C color) if (is(C : Color))
+pure auto isActualColor(Color color)
 {
     return color.isLight || color.isDark;
 }
-///
 @system unittest
 {
     assert(Color.red.isActualColor);
-    assert(Color.red.foreground.isActualColor);
     assert(Color.blueDark.isActualColor);
     assert(!Color.same.isActualColor);
 }
 
-/**
- * Params:
- *     color = A type of color. Either `Color`, `ForegroundColor`, or `BackgroundColor`
- */
-pure C light(C)(C color) if (is(C : Color))
+pure Color light(Color color)
 {
     if (color.isDark)
     {
@@ -168,21 +95,14 @@ pure C light(C)(C color) if (is(C : Color))
 
     return color;
 }
-///
 unittest
 {
     assert(Color.redDark.light == Color.red);
     assert(Color.red.light == Color.red);
-    assert(Color.redDark.foreground.light == Color.red.foreground);
-    assert(Color.redDark.background.light == Color.red.background);
     assert(Color.same.light == Color.same);
 }
 
-/**
- * Params:
- *     color = A type of color. Either `Color`, `ForegroundColor`, or `BackgroundColor`
- */
-pure C dark(C)(C color) if (is(C : Color))
+pure Color dark(Color color)
 {
     if (color.isLight)
     {
@@ -191,12 +111,9 @@ pure C dark(C)(C color) if (is(C : Color))
 
     return color;
 }
-///
 unittest
 {
     assert(Color.redDark.dark == Color.redDark);
     assert(Color.red.dark == Color.redDark);
-    assert(Color.redDark.foreground.dark == Color.redDark.foreground);
-    assert(Color.redDark.background.dark == Color.redDark.background);
     assert(Color.same.dark == Color.same);
 }

--- a/source/scone/output/types/color.d
+++ b/source/scone/output/types/color.d
@@ -1,5 +1,7 @@
 module scone.output.types.color;
 
+import scone.output.text_style : TextStyle;
+
 /**
  * All colors
  *
@@ -53,6 +55,29 @@ unittest
     // ensure there are 8 colors from Color.white(Dark) to Color.black(Dark)
     assert(Color.white - Color.black == 7);
     assert(Color.whiteDark - Color.blackDark == 7);
+}
+
+deprecated 
+{
+    TextStyle foreground(Color color)
+    {
+        return TextStyle().fg(color);
+    }
+    unittest
+    {
+        assert(TextStyle(Color.red, Color.same) == Color.red.foreground);
+        assert(TextStyle().fg(Color.red) == foreground(Color.red));
+    }
+
+    TextStyle background(Color color)
+    {
+        return TextStyle().bg(color);
+    }
+    unittest
+    {
+        assert(TextStyle(Color.same, Color.green) == Color.green.background);
+        assert(TextStyle().bg(Color.green) == background(Color.green));
+    }
 }
 
 pure auto isLight(Color color)


### PR DESCRIPTION
Removes the `ForegroundColor` and `BackgroundColor` mixin types, including all internal references to these.

`color.foreground()` and `color.background()` functions are ~also removed~ deprecated.