### PR TITLE
Rewrite Color to struct

### DIFF
--- a/source/scone/output/os/posix/partial_row_output_handler.d
+++ b/source/scone/output/os/posix/partial_row_output_handler.d
@@ -60,8 +60,10 @@ version (Posix)
 
                     if (updateColors)
                     {
-                        auto foregroundNumber = AnsiColor(currentCell.style.foreground).foregroundNumber;
-                        auto backgroundNumber = AnsiColor(currentCell.style.background).backgroundNumber;
+                        auto foregroundNumber = AnsiColorHelper(currentCell.style.foreground)
+                            .foregroundNumber;
+                        auto backgroundNumber = AnsiColorHelper(currentCell.style.background)
+                            .backgroundNumber;
                         print ~= text("\033[0;", foregroundNumber, ";", backgroundNumber, "m",);
                     }
 
@@ -111,45 +113,45 @@ version (Posix)
         private Buffer buffer;
     }
 
-    private struct AnsiColor
+    private struct AnsiColorHelper
     {
-        private Color color;
+        private AnsiColor ansi;
 
         this(Color color)
         {
-            this.color = color;
+            this.ansi = color.ansi;
         }
 
         int foregroundNumber()
         {
-            return ansiNumberCalculator(this.color);
+            return ansiNumberCalculator(this.ansi);
         }
 
         int backgroundNumber()
         {
             enum backgroundColorOffset = 10;
-            return this.ansiNumberCalculator(this.color) + backgroundColorOffset;
+            return this.ansiNumberCalculator(this.ansi) + backgroundColorOffset;
         }
 
-        private int ansiNumberCalculator(Color color) pure
+        private int ansiNumberCalculator(AnsiColor ansi) pure
         {
-            if (color == Color.initial)
+            if (ansi == AnsiColor.initial)
             {
                 return 39;
             }
 
-            if (color == Color.same)
+            if (ansi == AnsiColor.same)
             {
-                return cast(Color)-1;
+                return cast(AnsiColor)-1;
             }
 
-            assert(color < 16);
+            assert(ansi < 16);
 
             enum light = 90;
             enum dark = 30;
 
-            auto startIndex = color.isLight ? light : dark;
-            auto colorOffset = (cast(ubyte) color) % 8;
+            auto startIndex = ansi < 8 ? light : dark;
+            auto colorOffset = (cast(ubyte) ansi) % 8;
 
             return startIndex + colorOffset;
         }

--- a/source/scone/output/os/posix/partial_row_output_handler.d
+++ b/source/scone/output/os/posix/partial_row_output_handler.d
@@ -115,34 +115,36 @@ version (Posix)
 
     private struct AnsiColorHelper
     {
-        private AnsiColor ansi;
+        private Color color;
 
         this(Color color)
         {
-            this.ansi = color.ansi;
+            this.color = color;
         }
 
         int foregroundNumber()
         {
-            return ansiNumberCalculator(this.ansi);
+            return ansiNumberCalculator(this.color);
         }
 
         int backgroundNumber()
         {
             enum backgroundColorOffset = 10;
-            return this.ansiNumberCalculator(this.ansi) + backgroundColorOffset;
+            return this.ansiNumberCalculator(this.color) + backgroundColorOffset;
         }
 
-        private int ansiNumberCalculator(AnsiColor ansi) pure
+        private int ansiNumberCalculator(Color color)
         {
+            auto ansi = color.ansi;
+
+            if (color.state == ColorState.same)
+            {
+                return cast(AnsiColor)-1;
+            }
+
             if (ansi == AnsiColor.initial)
             {
                 return 39;
-            }
-
-            if (ansi == AnsiColor.same)
-            {
-                return cast(AnsiColor)-1;
             }
 
             assert(ansi < 16);

--- a/source/scone/output/os/windows/cell_converter.d
+++ b/source/scone/output/os/windows/cell_converter.d
@@ -34,116 +34,116 @@ version (Windows)
         {
             WORD attributes;
 
-            switch (cell.style.foreground)
+            switch (cell.style.foreground.ansi)
             {
-            case Color.initial:
+            case AnsiColor.initial:
                 // take the inital colors, and filter out all flags except the foreground ones
                 attributes |= (initialAttributes & (FOREGROUND_INTENSITY | FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE));
                 break;
-            case Color.blue:
+            case AnsiColor.blue:
                 attributes |= FOREGROUND_INTENSITY | FOREGROUND_BLUE;
                 break;
-            case Color.blueDark:
+            case AnsiColor.blueDark:
                 attributes |= FOREGROUND_BLUE;
                 break;
-            case Color.cyan:
+            case AnsiColor.cyan:
                 attributes |= FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_BLUE;
                 break;
-            case Color.cyanDark:
+            case AnsiColor.cyanDark:
                 attributes |= FOREGROUND_GREEN | FOREGROUND_BLUE;
                 break;
-            case Color.white:
+            case AnsiColor.white:
                 attributes |= FOREGROUND_INTENSITY | FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
                 break;
-            case Color.whiteDark:
+            case AnsiColor.whiteDark:
                 attributes |= FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
                 break;
-            case Color.black:
+            case AnsiColor.black:
                 attributes |= FOREGROUND_INTENSITY;
                 break;
-            case Color.blackDark:
+            case AnsiColor.blackDark:
                 attributes |= 0;
                 break;
-            case Color.green:
+            case AnsiColor.green:
                 attributes |= FOREGROUND_INTENSITY | FOREGROUND_GREEN;
                 break;
-            case Color.greenDark:
+            case AnsiColor.greenDark:
                 attributes |= FOREGROUND_GREEN;
                 break;
-            case Color.magenta:
+            case AnsiColor.magenta:
                 attributes |= FOREGROUND_INTENSITY | FOREGROUND_RED | FOREGROUND_BLUE;
                 break;
-            case Color.magentaDark:
+            case AnsiColor.magentaDark:
                 attributes |= FOREGROUND_RED | FOREGROUND_BLUE;
                 break;
-            case Color.red:
+            case AnsiColor.red:
                 attributes |= FOREGROUND_INTENSITY | FOREGROUND_RED;
                 break;
-            case Color.redDark:
+            case AnsiColor.redDark:
                 attributes |= FOREGROUND_RED;
                 break;
-            case Color.yellow:
+            case AnsiColor.yellow:
                 attributes |= FOREGROUND_INTENSITY | FOREGROUND_RED | FOREGROUND_GREEN;
                 break;
-            case Color.yellowDark:
+            case AnsiColor.yellowDark:
                 attributes |= FOREGROUND_RED | FOREGROUND_GREEN;
                 break;
             default:
                 break;
             }
 
-            switch (cell.style.background)
+            switch (cell.style.background.ansi)
             {
-            case Color.initial:
+            case AnsiColor.initial:
                 // take the inital colors, and filter out all flags except the background ones
                 attributes |= (initialAttributes & (BACKGROUND_INTENSITY | BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE));
                 break;
-            case Color.blue:
+            case AnsiColor.blue:
                 attributes |= BACKGROUND_INTENSITY | BACKGROUND_BLUE;
                 break;
-            case Color.blueDark:
+            case AnsiColor.blueDark:
                 attributes |= BACKGROUND_BLUE;
                 break;
-            case Color.cyan:
+            case AnsiColor.cyan:
                 attributes |= BACKGROUND_INTENSITY | BACKGROUND_GREEN | BACKGROUND_BLUE;
                 break;
-            case Color.cyanDark:
+            case AnsiColor.cyanDark:
                 attributes |= BACKGROUND_GREEN | BACKGROUND_BLUE;
                 break;
-            case Color.white:
+            case AnsiColor.white:
                 attributes |= BACKGROUND_INTENSITY | BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE;
                 break;
-            case Color.whiteDark:
+            case AnsiColor.whiteDark:
                 attributes |= BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE;
                 break;
-            case Color.black:
+            case AnsiColor.black:
                 attributes |= BACKGROUND_INTENSITY;
                 break;
-            case Color.blackDark:
+            case AnsiColor.blackDark:
                 attributes |= 0;
                 break;
-            case Color.green:
+            case AnsiColor.green:
                 attributes |= BACKGROUND_INTENSITY | BACKGROUND_GREEN;
                 break;
-            case Color.greenDark:
+            case AnsiColor.greenDark:
                 attributes |= BACKGROUND_GREEN;
                 break;
-            case Color.magenta:
+            case AnsiColor.magenta:
                 attributes |= BACKGROUND_INTENSITY | BACKGROUND_RED | BACKGROUND_BLUE;
                 break;
-            case Color.magentaDark:
+            case AnsiColor.magentaDark:
                 attributes |= BACKGROUND_RED | BACKGROUND_BLUE;
                 break;
-            case Color.red:
+            case AnsiColor.red:
                 attributes |= BACKGROUND_INTENSITY | BACKGROUND_RED;
                 break;
-            case Color.redDark:
+            case AnsiColor.redDark:
                 attributes |= BACKGROUND_RED;
                 break;
-            case Color.yellow:
+            case AnsiColor.yellow:
                 attributes |= BACKGROUND_INTENSITY | BACKGROUND_RED | BACKGROUND_GREEN;
                 break;
-            case Color.yellowDark:
+            case AnsiColor.yellowDark:
                 attributes |= BACKGROUND_RED | BACKGROUND_GREEN;
                 break;
             default:


### PR DESCRIPTION
Converts the `enum Color` to `struct Color`. The enum members have been replaced with static methods.

All features are not implemented (RGB), and there is still some voodoo magic going on with the conversion to ANSI color codes.