### PR TITLE
POSIX: Improve printing partial output

### DIFF
--- a/source/scone/output/os/posix/partial_row_output_handler.d
+++ b/source/scone/output/os/posix/partial_row_output_handler.d
@@ -10,6 +10,30 @@ version (Posix)
     import std.algorithm.searching : minElement, maxElement;
     import std.conv : text;
 
+    string printDataFromPartialRowOutput(PartialRowOutput[] pros)
+    {
+        import std.array : join;
+        import std.algorithm.iteration : map;
+        import std.conv : text;
+
+        return pros.map!(pro => text("\033[", pro.coordinate.y + 1, ";",
+                pro.coordinate.x + 1, "H", pro.output)).join();
+    }
+    ///
+    unittest
+    {
+        PartialRowOutput[] pros;
+
+        pros = [PartialRowOutput(Coordinate(0, 2), "foo")];
+        assert(pros.printDataFromPartialRowOutput() == "\033[3;1Hfoo");
+
+        pros = [
+            PartialRowOutput(Coordinate(0, 0), "foo"),
+            PartialRowOutput(Coordinate(2, 3), "bar"),
+        ];
+        assert(pros.printDataFromPartialRowOutput() == "\033[1;1Hfoo\033[4;3Hbar");
+    }
+
     struct PartialRowOutput
     {
         Coordinate coordinate;

--- a/source/scone/output/os/posix/posix_output.d
+++ b/source/scone/output/os/posix/posix_output.d
@@ -6,7 +6,7 @@ version (Posix)
     import scone.output.types.size : Size;
     import scone.output.types.coordinate : Coordinate;
     import scone.output.buffer : Buffer;
-    import scone.output.os.posix.partial_row_output_handler : PartialRowOutputHandler, PartialRowOutput;
+    import scone.output.os.posix.partial_row_output_handler : PartialRowOutputHandler, PartialRowOutput, printDataFromPartialRowOutput;
 
     import core.sys.posix.sys.ioctl : ioctl, winsize, TIOCGWINSZ;
     import std.stdio : writef, stdout;
@@ -38,14 +38,10 @@ version (Posix)
                 lastSize = currentSize;
             }
 
-            auto foos = PartialRowOutputHandler(buffer);
+            auto proh = PartialRowOutputHandler(buffer);
 
-            foreach (PartialRowOutput data; foos.partialRows())
-            {
-                this.cursorPosition(data.coordinate);
-                .writef(data.output);
-            }
-
+            
+            .writef(proh.partialRows.printDataFromPartialRowOutput());
             .writef("\033[0m");
 
             stdout.flush();

--- a/source/scone/output/os/posix/posix_output.d
+++ b/source/scone/output/os/posix/posix_output.d
@@ -6,7 +6,8 @@ version (Posix)
     import scone.output.types.size : Size;
     import scone.output.types.coordinate : Coordinate;
     import scone.output.buffer : Buffer;
-    import scone.output.os.posix.partial_row_output_handler : PartialRowOutputHandler, PartialRowOutput, printDataFromPartialRowOutput;
+    import scone.output.os.posix.partial_row_output_handler : PartialRowOutputHandler,
+        PartialRowOutput, printDataFromPartialRowOutput;
 
     import core.sys.posix.sys.ioctl : ioctl, winsize, TIOCGWINSZ;
     import std.stdio : writef, stdout;
@@ -40,7 +41,6 @@ version (Posix)
 
             auto proh = PartialRowOutputHandler(buffer);
 
-            
             .writef(proh.partialRows.printDataFromPartialRowOutput());
             .writef("\033[0m");
 


### PR DESCRIPTION
Explained more thoughtfully in #56.

> When printing on POSIX, each cell is not printed separately (like on Winodws), but rather are printed per line. The virtual cursor is moved to each line, then the content is printed at the cursor position. However, due to how the cursor is moved, it being an ANSI escape code being printed, it can be combined into one single print command.