### PR TITLE
Disable RGB color for Windows

### DIFF
--- a/source/scone/output/types/color.d
+++ b/source/scone/output/types/color.d
@@ -70,7 +70,7 @@ struct Color
         ");
     }
 
-    static Color rgb(ubyte r, ubyte g, ubyte b)
+    version (Posix) static Color rgb(ubyte r, ubyte g, ubyte b)
     {
         Color color = Color();
         color.colorState = ColorState.rgb;
@@ -114,10 +114,13 @@ unittest
     assert(b.ansiColor == AnsiColor.red);
     assert(b.rgbColor.isNull());
 
-    Color c = Color.rgb(123, 232, 123);
-    assert(c.colorState == ColorState.rgb);
-    assert(c.ansiColor.isNull());
-    assert(c.rgbColor == RGB(123, 232, 123));
+    version (Posix)
+    {
+        Color c = Color.rgb(123, 232, 123);
+        assert(c.colorState == ColorState.rgb);
+        assert(c.ansiColor.isNull());
+        assert(c.rgbColor == RGB(123, 232, 123));
+    }
 
     Color d = Color.same;
     assert(d.colorState == ColorState.same);

--- a/source/scone/output/types/color.d
+++ b/source/scone/output/types/color.d
@@ -80,21 +80,24 @@ struct Color
         return color;
     }
 
-    ColorState state()
+    package(scone)
     {
-        return this.colorState;
-    }
+        ColorState state()
+        {
+            return this.colorState;
+        }
 
-    AnsiColor ansi()
-    {
-        assert(!this.ansiColor.isNull);
-        return this.ansiColor.get();
-    }
+        AnsiColor ansi()
+        {
+            assert(!this.ansiColor.isNull);
+            return this.ansiColor.get();
+        }
 
-    RGB rgb()
-    {
-        assert(!this.rgbColor.isNull);
-        return this.rgbColor.get();
+        RGB rgb()
+        {
+            assert(!this.rgbColor.isNull);
+            return this.rgbColor.get();
+        }
     }
 
     private ColorState colorState = ColorState.ansi;


### PR DESCRIPTION
Currently, the only way I know of to get RGB color on Windows is to use ANSI escape sequences. The current implementation where POSIX and Windows code is completely separated, used completely differently (internally), and are each compiled away from the other OS with `version (…)`.

As an added bonus, command prompts before Windows 10 do not understand ANSI escape sequences (AFAIK).

This means that, currently, there is no straight forward way to implement RGB colors into Windows. I am extremely open to having RGB in Windows as well, only that it can be properly implemented.

Closes #63, and in turn also closes #37.